### PR TITLE
Add smooth scrolling and active nav highlighting

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -57,4 +57,89 @@
     chips.forEach(x => x.setAttribute('aria-selected', x === c ? 'true' : 'false'));
     render();
   }));
+
+  // Smooth scroll & active navigation state
+  const anchors = $$('a[href^="#"]:not([href="#"])');
+  anchors.forEach(link => {
+    const targetId = link.getAttribute('href').slice(1);
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    link.addEventListener('click', evt => {
+      evt.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth' });
+      history.pushState(null, '', `#${targetId}`);
+    });
+  });
+
+  const navLinks = $$('.menu a[href^="#"]:not([href="#"])');
+  const sections = navLinks
+    .map(link => {
+      const id = link.getAttribute('href').slice(1);
+      const section = document.getElementById(id);
+      return section ? { link, section } : null;
+    })
+    .filter(Boolean);
+
+  function setActiveLink(activeLink) {
+    navLinks.forEach(link => {
+      if (link === activeLink) {
+        link.classList.add('active');
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.classList.remove('active');
+        link.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function updateActiveSection() {
+    if (!sections.length) return;
+    const scrollPos = window.scrollY + 120;
+    let current = null;
+
+    for (const { section, link } of sections) {
+      const top = section.offsetTop;
+      const bottom = top + section.offsetHeight;
+      if (scrollPos >= top && scrollPos < bottom) {
+        current = link;
+        break;
+      }
+    }
+
+    if (!current) {
+      const last = sections[sections.length - 1];
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 2) {
+        current = last?.link || null;
+      }
+    }
+
+    setActiveLink(current);
+  }
+
+  function throttle(fn, wait) {
+    let last = 0;
+    let timeout;
+    return function (...args) {
+      const now = Date.now();
+      const remaining = wait - (now - last);
+      if (remaining <= 0) {
+        clearTimeout(timeout);
+        timeout = null;
+        last = now;
+        fn.apply(this, args);
+      } else if (!timeout) {
+        timeout = setTimeout(() => {
+          last = Date.now();
+          timeout = null;
+          fn.apply(this, args);
+        }, remaining);
+      }
+    };
+  }
+
+  const onScroll = throttle(updateActiveSection, 100);
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', throttle(updateActiveSection, 200));
+  updateActiveSection();
 })();


### PR DESCRIPTION
## Summary
- add smooth scrolling for internal anchor links
- highlight the active navigation item as the page scrolls
- throttle the scroll handler to avoid excessive work

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de70e95d488326a8fae6dcf1c52422